### PR TITLE
Fedora 32 no longer appears to supports rpm-python package

### DIFF
--- a/devel/ansible/roles/nuancier-dev/tasks/main.yml
+++ b/devel/ansible/roles/nuancier-dev/tasks/main.yml
@@ -20,7 +20,7 @@
     - openssl-devel
     - python3-devel
     - redhat-rpm-config
-    - rpm-python
+    - python3-rpm
 
 # Add various helpful configuration files
 - name: Install a custom bashrc


### PR DESCRIPTION
Change rpm-python package to python3-rpm package. If it isn't a direct update for rpm-python, it at least seems to cover everything we are using it for.